### PR TITLE
Remove unnecessary clones

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -232,12 +232,12 @@ impl Game {
                         let d = body.transform(Direction::Down, 1);
                         let r = body.transform(Direction::Right, 1);
                         let u = if body.y == 0 {
-                            body.clone()
+                            *body
                         } else {
                             body.transform(Direction::Up, 1)
                         };
                         let l = if body.x == 0 {
-                            body.clone()
+                            *body
                         } else {
                             body.transform(Direction::Left, 1)
                         };
@@ -326,7 +326,7 @@ impl Game {
             .snake
             .get_head_point()
             .transform(self.snake.get_direction(), 1);
-        let mut next_body_points = self.snake.get_body_points().clone();
+        let mut next_body_points = self.snake.get_body_points();
         next_body_points.remove(next_body_points.len() - 1);
         next_body_points.remove(0);
 

--- a/src/snake.rs
+++ b/src/snake.rs
@@ -24,7 +24,7 @@ impl Snake {
     }
 
     pub fn get_head_point(&self) -> Point {
-        self.body.first().unwrap().clone()
+        *self.body.first().unwrap()
     }
 
     pub fn get_body_points(&self) -> Vec<Point> {
@@ -32,7 +32,7 @@ impl Snake {
     }
 
     pub fn get_direction(&self) -> Direction {
-        self.direction.clone()
+        self.direction
     }
 
     pub fn contains_points(&self, point: &Point) -> bool {


### PR DESCRIPTION
Some of these types implement `Copy` which is generally cheaper than `Clone`.

You can find unnecessary clones with `clippy` (and also fix them automatically with `cargo clippy --fix -Z unstable-options` which requires a nightly installation I think).